### PR TITLE
Soporte para guardado de diferentes tablas de ruteo

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -53,6 +53,8 @@ function fail() {
 echo -e "$1: \e[31mFAIL\e[0m"
 }
 
+[ -f $CONFIGS_DIR/tables ] && ( echo "Salvando rt_tables original en ${CONFIGS_DIR}rt_tables"; cp /etc/iproute2/rt_tables $CONFIGS_DIR/rt_tables )
+
 for file in $CONFIGS_DIR/*; do
   filename=$(basename "$file")
   cmd_type="${filename##*.}"
@@ -77,6 +79,7 @@ for file in $CONFIGS_DIR/*; do
       ;;
     "bash")
       cmd="$cmd_base bash -E -c "
+      [ -f $CONFIGS_DIR/tables ] && (eval "$cmd 'cat $CONFIGS_DIR/tables > /etc/iproute2/rt_tables'")
       while read line; do
         eval "$cmd '$line'" &>/dev/null
       done < "$file"

--- a/restore.sh
+++ b/restore.sh
@@ -54,15 +54,13 @@ function fail() {
 }
 
 # Si tengo tablas de ruteo que restaurar y no tengo un backup del origina
-# Creo copia del original
-if [ -f $CONFIGS_DIR/tables -a ! -f $CONFIGS_DIR/rt_tables ]; then
-  echo "Salvando rt_tables original en $CONFIGS_DIR/rt_tables"
-  cp /etc/iproute2/rt_tables $CONFIGS_DIR/rt_tables
-fi
-
-# Si existe archivo de tablas de rutas tomo el primer socket y le envio el archivo
-if [ -f $CONFIGS_DIR/tables ]; then
-  # Me quedo con el primer router que encuentro
+if [ -f $CONFIGS_DIR/tables ] && !(diff $CONFIGS_DIR/tables /etc/iproute2/rt_tables &>/dev/null); then
+  # Creo copia del original
+  if [ ! -f $CONFIGS_DIR/rt_tables ]; then
+    echo "Salvando rt_tables original en $CONFIGS_DIR/rt_tables"
+    cp /etc/iproute2/rt_tables $CONFIGS_DIR/rt_tables
+  fi
+  # Me quedo con el primer nodo que encuentro
   router=`find $CORE -type s -print -quit`
   eval "/usr/sbin/vcmd -c $router -- bash -E -c 'cat $CONFIGS_DIR/tables > /etc/iproute2/rt_tables'"
 fi

--- a/save.sh
+++ b/save.sh
@@ -33,7 +33,8 @@ else
 fi
 
 # Ruta pasada como argumento
-OUTPUT_DIR=$1
+OUTPUT_DIR=${1%/}
+shift
 
 # Chequea si es el directio actual
 # o la ruta es relativa.
@@ -43,9 +44,9 @@ if [ "${#OUTPUT_DIR}" -eq "1" ] && [ "${OUTPUT_DIR:0:1}" = "." ]; then
   OUTPUT_DIR="$PWD/"
 elif [ "${OUTPUT_DIR:0:1}" != "/" ]; then
   # es relativo
-  OUTPUT_DIR="${PWD}/$OUTPUT_DIR/"
+  OUTPUT_DIR="${PWD}/$OUTPUT_DIR"
 else
-  OUTPUT_DIR="$1/"
+  OUTPUT_DIR="$OUTPUT_DIR"
 fi
 
 # Creo el directorio donde se guardará la configuración
@@ -75,7 +76,7 @@ for file in $CORE/*; do
     # Obtengo nombre del archivo
     filename="$(basename $file)"
     # Obtengo path absoluto del archivo a guardar
-    output_file="${OUTPUT_DIR}${filename}"
+    output_file="$OUTPUT_DIR/$filename"
     # Verifico si es un router
     if (_is_router $file); then
       config=`/usr/sbin/vcmd -c $file -- vtysh -E -c 'show run' 2>/dev/null | tail -n+5`
@@ -108,4 +109,4 @@ for file in $CORE/*; do
 done
 
 route_table=`cat /etc/iproute2/rt_tables`
-persist "$route_table" "${OUTPUT_DIR}tables"
+persist "$route_table" "$OUTPUT_DIR/tables"


### PR DESCRIPTION
Se agregó soporte para guardar

- Archivo de tablas de ruteo (rt_tables) + backup de archivo original para evitar conflictos.
- Configuración de cada tabla (con `ip route ls table <tabla>`)
- Reglas de las tablas de ruteo (con `ip rule`)